### PR TITLE
Fix `havoc` instruction

### DIFF
--- a/src/analysis/semantics.rs
+++ b/src/analysis/semantics.rs
@@ -531,11 +531,8 @@ fn execute_havoc<T:EvmState>(mut state: T, k: usize) -> Outcome<T> {
     assert!(k < stack.size());
     // Havoc value at position k
     let val = stack.set(k,T::Word::from(w256::from(0))).havoc();
-    println!("HAVOC {k}");
     // Assign it back
     stack.set(k,val);
-    // Move to next instruction
-    state.skip(1);    
     //    
     Outcome::Continue(state)
 }


### PR DESCRIPTION
This fixes the `havoc` instruction so that it now works correctly.  This was achieved by modifying the `trace()` loop.