### PR TITLE
Fix havoc analysis

### DIFF
--- a/src/analysis/havoc.rs
+++ b/src/analysis/havoc.rs
@@ -57,7 +57,7 @@ pub fn insert_havocs(mut insns: Vec<Instruction>) -> Vec<Instruction> {
     for i in 0..insns.len() {
         if detect_cycle(i,&deps, &mut visited) {
             havocs.push(i+1);
-        }
+        } 
     }
     // Insert havoc statements
     for (i,idx) in havocs.iter().enumerate() {
@@ -91,11 +91,11 @@ fn detect_cycle(i: usize, deps: &Dependencies, visited: &mut [bool]) -> bool {
                 // Check for match
                 if *dep == i { return true; }
                 //
-                if !visited[n] {
+                if !visited[*dep] {
                     // Mark as visited
-                    visited[n] = true;
+                    visited[*dep] = true;
                     // Mark for subsequent search
-                    worklist.push(n);
+                    worklist.push(*dep);
                 }
             }
         }


### PR DESCRIPTION
This fixes the havoc analysis by adding dependencies to `dup` instructions as special cases.  Otherwise, you can't follow them to look for loops.  This fixes the wrapped ether contract, though I don't believe the havoc analysis is perfect yet.  It needs quite a lot of work!!