### PR TITLE
Improve memory analysis

### DIFF
--- a/src/analysis/state.rs
+++ b/src/analysis/state.rs
@@ -164,11 +164,11 @@ where S:EvmStack,
 
 impl<S,M,T> fmt::Display for ConcreteState<S,M,T>
 where S:EvmStack+Default+fmt::Display,
-      M:EvmMemory<Word=S::Word>+Default,
+      M:EvmMemory<Word=S::Word>+Default+fmt::Display,
       T:EvmStorage<Word=S::Word>+Default   
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"|{}|",self.stack)?;
+        write!(f,"|{}|{}|",self.stack,self.memory)?;        
         Ok(())
     }
 }

--- a/src/bin/evmil.rs
+++ b/src/bin/evmil.rs
@@ -18,7 +18,7 @@ use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 //
-use evmil::analysis::{aw256,ConcreteStack,ConcreteState,UnknownMemory,UnknownStorage};
+use evmil::analysis::{aw256,ConcreteStack,ConcreteState,ConcreteMemory,UnknownStorage};
 use evmil::analysis::{find_dependencies,insert_havocs,trace};
 use evmil::bytecode::{Assembly,Instruction,StructuredSection};
 use evmil::il::{Compiler,Parser};
@@ -251,7 +251,7 @@ fn disassemble_dep_code(insns: &[Instruction]) {
     } 
 }
 
-type DebugState = ConcreteState<ConcreteStack<aw256>,UnknownMemory<aw256>,UnknownStorage<aw256>>;
+type DebugState = ConcreteState<ConcreteStack<aw256>,ConcreteMemory<aw256>,UnknownStorage<aw256>>;
 
 // Disassemble a code section _with_ debug information.  Note that
 // this can fail if the underlying static analysis fails.

--- a/src/util/word256.rs
+++ b/src/util/word256.rs
@@ -18,9 +18,11 @@ use crate::util;
 #[allow(non_camel_case_types)]
 pub type w256 = Uint<256,4>;
 
+pub const W256_ZERO : w256 = w256::from_limbs([0,0,0,0]);
 pub const W256_ONE : w256 = w256::from_limbs([1,0,0,0]);
 pub const W256_TWO : w256  = w256::from_limbs([2,0,0,0]);
 pub const W256_THREE : w256  = w256::from_limbs([3,0,0,0]);
+pub const W256_THIRTYTWO : w256  = w256::from_limbs([32,0,0,0]);
 
 // =====================================================================
 // Min / Max


### PR DESCRIPTION
This puts in place an improved (but still relatively simplistic) memory analysis.  For the WETH contract, it tracks the free memory pointer relatively well.