### PR TITLE
Enable `BlockGraph` construction from `BlockVec`

### DIFF
--- a/src/analysis/cfg.rs
+++ b/src/analysis/cfg.rs
@@ -28,7 +28,18 @@ impl<'a> From<&'a [Instruction]> for BlockGraph<'a>
     /// sequence.
     fn from(insns: &'a [Instruction]) -> Self {
         // Construct block graph
-        let mut graph = BlockGraph::new(insns.len()+1,BlockVec::new(insns));
+        BlockGraph::from(BlockVec::new(insns))
+    }
+}
+
+impl<'a> From<BlockVec<'a>> for BlockGraph<'a>
+{
+    /// Construct a graph of the basic blocks for a given instruction
+    /// sequence.
+    fn from(blocks: BlockVec<'a>) -> Self {
+        let insns = blocks.insns();
+        // Construct block graph
+        let mut graph = BlockGraph::new(blocks.len()+1,blocks);
         // Compute analysis results
         let init = DefaultState::new();
         // Run the abstract trace

--- a/src/bytecode/block_vec.rs
+++ b/src/bytecode/block_vec.rs
@@ -49,6 +49,11 @@ impl<'a> BlockVec<'a> {
         self.insn_offsets.len()
     }
 
+    /// Return the underlying instruction sequence for this block vector.
+    pub fn insns(&self) -> &'a [Instruction] {
+        &self.insns
+    }
+    
     /// Get the _ith_ block within this decomposition.
     pub fn get(&self, index: usize) -> &'a [Instruction] {
         let m = if index == 0 { 0 } else { self.insn_offsets[index-1] };

--- a/src/util/digraph_algorithms.rs
+++ b/src/util/digraph_algorithms.rs
@@ -9,7 +9,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::util::{Digraph,EdgeSet,Seq,SortedVec};
+use crate::util::{Digraph,EdgeSet,Seq};
 
 // ===================================================================
 // Dominators


### PR DESCRIPTION
This just adds a bit more flexibility into the api at essentially zero cost.  It just means we can, in principle, construct a `BlockGraph` from an arbitrary block decomposition.