### PR TITLE
Fix for `DATA` instructions

### DIFF
--- a/src/bytecode/instruction.rs
+++ b/src/bytecode/instruction.rs
@@ -313,7 +313,8 @@ impl Instruction {
             CALL|CALLCODE => 7,
             // Virtual instructions
             HAVOC(_) => 0,
-            _ => { unreachable!(); }
+            DATA(_) => 0,
+            _ => { unreachable!("{:?}",self); }
         }
     }
     


### PR DESCRIPTION
This is a simple fix which identifies that data bytes are instructions with zero operands.