### PR TITLE
Support `push0`

### DIFF
--- a/src/analysis/semantics.rs
+++ b/src/analysis/semantics.rs
@@ -143,6 +143,7 @@ where T::Word : Top {
         JUMP => execute_jump(state),
         JUMPI => execute_jumpi(state),
 
+        PUSH0 => execute_push(state,&[]),        
         // ===========================================================
         // 60 & 70s: Push Operations
         // ===========================================================
@@ -509,7 +510,7 @@ fn execute_swap<T:EvmState>(mut state: T, k: usize) -> Outcome<T> {
     assert!(1 <= k && k <= 16);
     let stack = state.stack_mut();
     //
-    if !stack.has_operands(k) {
+    if !stack.has_operands(k+1) {
         Outcome::Exception(StackUnderflow)
     } else {
         // FIXME: a proper swap operation would improve performance

--- a/src/bytecode/instruction.rs
+++ b/src/bytecode/instruction.rs
@@ -173,6 +173,7 @@ pub enum Instruction {
     JUMPDEST,
     RJUMP(usize),  // EIP4200
     RJUMPI(usize), // EIP4200
+    PUSH0, // EIP3855
     // 60 & 70s: Push Operations
     PUSH(Vec<u8>),
     // 80s: Duplicate Operations
@@ -296,7 +297,7 @@ impl Instruction {
             MLOAD|SLOAD|JUMP|POP|RJUMPI(_) => 1,            
             MSTORE|MSTORE8|SSTORE|JUMPI => 2,
             // 60s & 70s: Push Operations            
-            PUSH(_) => 0,
+            PUSH0|PUSH(_) => 0,
             // 80s: Duplication Operations
             DUP(_) => 0,
             // 90s: Swap Operations
@@ -395,6 +396,7 @@ impl Instruction {
             JUMPDEST => opcode::JUMPDEST,
             RJUMP(_) => opcode::RJUMP,
             RJUMPI(_) => opcode::RJUMPI,
+            PUSH0 => opcode::PUSH0,
             // 60s & 70s: Push Operations            
             PUSH(bs) => {
                 if bs.is_empty() || bs.len() > 32 {
@@ -523,6 +525,7 @@ impl Instruction {
             //     let arg = [bytes[pc+1],bytes[pc+2]];
             //     RJUMPI(i16::from_be_bytes(arg))
             // }
+            opcode::PUSH0 => PUSH0,
             // 60s & 70s: Push Operations
             opcode::PUSH1..=opcode::PUSH32 => {
                 let m = pc + 1;

--- a/src/bytecode/opcode.rs
+++ b/src/bytecode/opcode.rs
@@ -81,6 +81,7 @@ pub const GAS: u8 = 0x5a;
 pub const JUMPDEST: u8 = 0x5b;
 pub const RJUMP: u8 = 0x5c;
 pub const RJUMPI: u8 = 0x5d;
+pub const PUSH0: u8 = 0x5f;
 // 60s & 70s: Push Operations
 pub const PUSH1: u8 = 0x60;
 pub const PUSH2: u8 = 0x61;

--- a/src/bytecode/parser.rs
+++ b/src/bytecode/parser.rs
@@ -344,6 +344,7 @@ fn parse_opcode(insn: &str) -> Result<Instruction,ParseError> {
         "msize"|"MSIZE" => MSIZE,
         "gas"|"GAS" => GAS,
         "jumpdest"|"JUMPDEST" => JUMPDEST,
+        "push0" => PUSH0,
         // 60s & 70s: Push Operations
         "push"|"PUSH" => {
             // Should be impossible to get here!


### PR DESCRIPTION
This adds support for the `push0` instruction, as per EIP3855.